### PR TITLE
Fix to previously PL

### DIFF
--- a/task-manager/components/Legal.module.css
+++ b/task-manager/components/Legal.module.css
@@ -33,7 +33,7 @@
   mask-image: radial-gradient(circle at center, black, transparent 80%);
 }
 
-[data-theme='dark'] .heroBgGrid {
+:root[class~="dark"] .heroBgGrid {
   background-image: linear-gradient(var(--gray-800) 1px, transparent 1px),
     linear-gradient(90deg, var(--gray-800) 1px, transparent 0.5px);
 }
@@ -103,8 +103,8 @@
   font-size: 1.05rem;
 }
 
-[data-theme='dark'] .content p {
-  color: var(--gray-400);
+:root[class~="dark"] .content p {
+  color: var(--gray-300);
 }
 
 .content ul {
@@ -115,11 +115,12 @@
 .content li {
   margin-bottom: 0.75rem;
   color: var(--gray-600);
+  line-height: 1.8;
   font-size: 1.05rem;
 }
 
-[data-theme='dark'] .content li {
-  color: var(--gray-400);
+:root[class~="dark"] .content li {
+  color: var(--gray-300);
 }
 
 .content a {

--- a/task-manager/components/Navbar.module.css
+++ b/task-manager/components/Navbar.module.css
@@ -47,6 +47,7 @@
   font-size: 1.125rem;
   color: var(--foreground);
   letter-spacing: -0.02em;
+  text-decoration: none;
 }
 
 .navLinks {

--- a/task-manager/components/Navbar.tsx
+++ b/task-manager/components/Navbar.tsx
@@ -20,11 +20,19 @@ export function Navbar() {
         <div 
           className={styles.logo} 
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              window.scrollTo({ top: 0, behavior: 'smooth' });
+            }
+          }}
         >
           <div className={styles.logoIcon}>
             <Image src="/apple-touch-icon.png" alt="Vela Works Logo" width={32} height={32} />
           </div>
-          <Link href="/" className={styles.logoText} style={{textDecoration: 'none', color: 'inherit'}}>Vela Works</Link>
+          <Link href="/" className={styles.logoText}>Vela Works</Link>
         </div>
         <div className={styles.navLinks}>
           <Link href="/#features">Features</Link>
@@ -55,6 +63,8 @@ export function Navbar() {
         <button 
           className={styles.mobileMenuBtn}
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+          aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
+          aria-expanded={isMobileMenuOpen}
         >
           <ListBulletsIcon />
         </button>


### PR DESCRIPTION
Dark Mode Consistency: Fixed 3 selectors in Legal.module.css to use :root[class~="dark"] instead of [data-theme='dark']

Accessibility Improvements:
Logo now keyboard accessible (Enter/Space keys)
Mobile menu button has descriptive aria-label
Mobile menu button has aria-expanded state