### PR TITLE
fix: optimize middleware matcher to exclude landing page

### DIFF
--- a/task-manager/proxy.ts
+++ b/task-manager/proxy.ts
@@ -40,6 +40,7 @@ export async function proxy(request: NextRequest) {
 }
 export const config = {
   matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/dashboard/:path*',
+    '/auth/:path*',
   ],
 }


### PR DESCRIPTION
This PR addresses the "Redirect error" reported in Google Search Console for the landing page